### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ return {
     "Owen-Dechow/nvim_json_graph_view",
     dependencies = {
         "Owen-Dechow/graph_view_yaml_parser", -- Optional: add YAML support
-    }
+    },
     opts = {
         round_units = false
     }


### PR DESCRIPTION
lazy.vim suggested setup was missing a ','

I had this issue while installing `videre` with `lazy.vim`.
I know the contributing guidelines indicates opening an issue, but I think this is trivial enough :) 
